### PR TITLE
Remove trailing $ in sed to allow for comments after SCRIPT_VERSION

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -388,7 +388,7 @@ echo "Change: $CHANGE_DESC"
 sed -i.bak "s/^# VERSION:[[:space:]]*[0-9][0-9.]*$/# VERSION:     $NEW_VERSION/" "$SCRIPT_FILE"
 
 # Update SCRIPT_VERSION constant (only lines with actual version numbers, not variables)
-sed -i.bak "s/^readonly SCRIPT_VERSION=\"[0-9][0-9.]*\"$/readonly SCRIPT_VERSION=\"$NEW_VERSION\"/" "$SCRIPT_FILE"
+sed -i.bak "s/^readonly SCRIPT_VERSION=\"[0-9][0-9.]*\"/readonly SCRIPT_VERSION=\"$NEW_VERSION\"/" "$SCRIPT_FILE"
 
 # Update CHANGELOG/History in script header (add new entry after the section header)
 # Uses awk instead of sed: BSD sed on macOS does not support 0,/pattern/ address ranges


### PR DESCRIPTION
Just removing a trailing $ from sed command so that way SCRIPT_VERSION can be updated if there is a trailing comment. 